### PR TITLE
fix: add osc badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ It's just a POC for now. The output is hard-coded to be PNG.
 
 The Rust Image Processor is a lightweight API that offers endpoints for scaling and manipulating images. It is designed to be efficient and easy to use for image-processing tasks.
 
+<br/>
+<div align="center">
+
+[![Badge OSC](https://img.shields.io/badge/Evaluate-24243B?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTIiIGZpbGw9InVybCgjcGFpbnQwX2xpbmVhcl8yODIxXzMxNjcyKSIvPgo8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiLz4KPGRlZnM%2BCjxsaW5lYXJHcmFkaWVudCBpZD0icGFpbnQwX2xpbmVhcl8yODIxXzMxNjcyIiB4MT0iMTIiIHkxPSIwIiB4Mj0iMTIiIHkyPSIyNCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgo8c3RvcCBzdG9wLWNvbG9yPSIjQzE4M0ZGIi8%2BCjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzREQzlGRiIvPgo8L2xpbmVhckdyYWRpZW50Pgo8L2RlZnM%2BCjwvc3ZnPgo%3D)](https://app.osaas.io/browse/eyevinn-rust-image-processor)
+
+</div>
+
 ## Usage
 
 To use the Rust Image Processor, send HTTP requests to its endpoints for scaling and manipulating images.


### PR DESCRIPTION
![image](https://github.com/Eyevinn/rust-image-processor/assets/61239524/e15b88a3-8d1d-4277-a413-51f3ac59f8e1)
